### PR TITLE
Add fallback method for older modems

### DIFF
--- a/gsm.go
+++ b/gsm.go
@@ -139,8 +139,15 @@ func lineChannel(r io.Reader) chan string {
 
 var reQuestion = regexp.MustCompile(`AT(\+[A-Z]+)`)
 
-func parsePacket(status string, header string, body string) Packet {
-	if header == "" && (status == "OK" || status == "ERROR") {
+func isFinalStatus(status string) bool {
+	return status == "OK" ||
+		status == "ERROR" ||
+		strings.Contains(status, "+CMS ERROR") ||
+		strings.Contains(status, "+CME ERROR")
+}
+
+func parsePacket(status, header, body string) Packet {
+	if header == "" && isFinalStatus(status) {
 		if status == "OK" {
 			return OK{}
 		} else {
@@ -201,13 +208,17 @@ func parsePacket(status string, header string, body string) Packet {
 					iargs = append(iargs, iarg)
 				}
 			}
-			if len(iargs) != 6 {
-				break
+			if len(iargs) == 6 {
+				return StorageInfo{
+					iargs[0], iargs[1], iargs[2], iargs[3], iargs[4], iargs[5],
+				}
+			} else if len(iargs) == 4 {
+				return StorageInfo{
+					iargs[0], iargs[1], iargs[2], iargs[3], 0, 0,
+				}
 			}
+			break
 
-			return StorageInfo{
-				iargs[0], iargs[1], iargs[2], iargs[3], iargs[4], iargs[5],
-			}
 		}
 	case "":
 		if status == "OK" {
@@ -235,7 +246,7 @@ func (self *Modem) listen() {
 				}
 				header = line
 				body = ""
-			} else if line == "OK" || line == "ERROR" {
+			} else if isFinalStatus(line) {
 				packet := parsePacket(line, header, body)
 				self.rx <- packet
 				header = ""

--- a/gsm.go
+++ b/gsm.go
@@ -305,7 +305,10 @@ func (self *Modem) init() error {
 	// use combined storage (MT)
 	msg, err := self.send("+CPMS", "SM", "SM", "SM")
 	if err != nil {
-		return err
+		msg, err = self.send("+CPMS", "SM", "SM")
+		if err != nil {
+			return err
+		}
 	}
 	sinfo := msg.(StorageInfo)
 	log.Printf("Set SMS Storage: %d/%d used\n", sinfo.UsedSpace1, sinfo.MaxSpace1)

--- a/mock.go
+++ b/mock.go
@@ -45,7 +45,7 @@ func (self *MockSerialPort) Write(b []byte) (int, error) {
 	}
 	i := self.replay[0]
 	if strings.Index(i, "->") != 0 {
-		fmt.Printf("Replay isn't data to send:", i)
+		fmt.Println("Replay isn't data to send:", i)
 		panic("fail")
 	}
 	expected := i[2:]


### PR DESCRIPTION
Hi,

I have some old modem which only supports 2 instead of 3 storages in `AT+CPMS`.
When I open a port with this older modem, the initiatlization fails.

```
2018/08/23 14:36:56 Write("AT+CPMS=\"SM\",\"SM\",\"SM\"\r\n") = (24, <nil>)
2018/08/23 14:36:56 Read("\r\n+CMS ERROR: 302\r\n") = (19, <nil>)
```

```
AT+CPMS=?

+CPMS: (("SM","BM","SR"),("SM"))

OK
AT+CPMS?

+CPMS: "SM",13,20,"SM",13,20

OK
ATI

 WAVECOM MODEM

 MULTIBAND  900E  1800

OK
```

It is very old. When I've looked online I found some more examples of these modems which have the same behavior. e.g. http://www.logicbus.com.mx/pdf/31/Comandos_AT_generales.pdf

